### PR TITLE
Add getCollectionTree sql to ModuleDBTool

### DIFF
--- a/Products/RhaptosModuleStorage/ModuleDBTool.py
+++ b/Products/RhaptosModuleStorage/ModuleDBTool.py
@@ -82,6 +82,7 @@ class ModuleDBTool(UniqueObject, SimpleItem):
     sqlGetFileByMd5 = ZSQLFile('sql/getFileByMd5', globals(), __name__='sqlGetFileByMd5')
     sqlInsertFile = ZSQLFile('sql/insertFile', globals(), __name__='sqlInsertFile')
     sqlInsertModuleFile = ZSQLFile('sql/insertModuleFile', globals(), __name__='sqlInsertModuleFile')
+    sqlGetCollectionTree = ZSQLFile('sql/getCollectionTree', globals(), __name__='sqlGetCollectionTree')
 
     # Member-data functions
     sqlGetAuthorByFirstChar = ZSQLFile('sql/getAuthorByFirstChar', globals(), __name__='sqlGetAuthorByFirstChar')

--- a/Products/RhaptosModuleStorage/sql/getCollectionTree.sql
+++ b/Products/RhaptosModuleStorage/sql/getCollectionTree.sql
@@ -1,0 +1,11 @@
+<dtml-comment>
+arguments: id:string version:string
+</dtml-comment>
+
+SELECT tree_to_json_for_legacy(
+    m.uuid::TEXT,
+    CONCAT_WS('.', m.major_version, m.minor_version))
+FROM modules m
+WHERE
+    <dtml-sqltest id column="m.moduleid" type="string"> AND
+    <dtml-sqltest version column="m.version" type="string">


### PR DESCRIPTION
It returns a json collection tree same as webview but with legacy
id and version.

https://trello.com/c/SDB801FO/1062-13-implement-rewrite-to-legacy-publishing

This depends on https://github.com/Connexions/cnx-archive/commit/0e3ddea891506798d015856cb33ae2c1fa9e9425 (on publish-to-legacy)