### PR TITLE
expilicitly order history by versions

### DIFF
--- a/Products/RhaptosModuleStorage/sql/getHistory.sql
+++ b/Products/RhaptosModuleStorage/sql/getHistory.sql
@@ -8,4 +8,4 @@ max_rows: 0
 SELECT version, revised, submitter, submitlog
 FROM modules
 WHERE <dtml-sqltest id column="moduleid" type="string">
-ORDER BY revised DESC
+ORDER BY major_version DESC, minor_version DESC, revised DESC


### PR DESCRIPTION
Revised is not always correct for minor versions - impacts ZODB collection creation from db - if out of order, the attempt to create one RhaptosCollection object per major version fails for some collections.